### PR TITLE
Update Linux Google Chrome path

### DIFF
--- a/swi.sublime-settings
+++ b/swi.sublime-settings
@@ -2,7 +2,7 @@
 	"chrome_path": {
 		"osx": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
 		"windows": "C:\\Program Files\\Google\\Chrome\\chrome.exe",
-		"linux": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+		"linux": "/usr/bin/google-chrome"
 	},
 	"chrome_remote_port": "9222",
 	"breakpoint_scope": "swi.breakpoint",


### PR DESCRIPTION
Update path of Google Chrome for Linux. This is were Google Chrome is installed via its officially installer.
