### PR TITLE
Allow setting to specify which Chrome profile to load

### DIFF
--- a/swi.py
+++ b/swi.py
@@ -233,7 +233,7 @@ class SwiDebugStartChromeCommand(sublime_plugin.TextCommand):
         window = sublime.active_window()
 
         window.run_command('exec', {
-            "cmd": [os.getenv('GOOGLE_CHROME_PATH', '')+get_setting('chrome_path')[sublime.platform()], '--remote-debugging-port=' + get_setting('chrome_remote_port')]
+            "cmd": [os.getenv('GOOGLE_CHROME_PATH', '')+get_setting('chrome_path')[sublime.platform()], '--remote-debugging-port=' + get_setting('chrome_remote_port'), '--profile-directory='+ get_setting('chrome_profile'), '']
         })
 
 

--- a/swi.sublime-settings
+++ b/swi.sublime-settings
@@ -4,6 +4,7 @@
 		"windows": "C:\\Program Files\\Google\\Chrome\\chrome.exe",
 		"linux": "/usr/bin/google-chrome"
 	},
+	"chrome_profile": "Default",
 	"chrome_remote_port": "9222",
 	"breakpoint_scope": "swi.breakpoint",
 	"current_line_scope": "swi.current",


### PR DESCRIPTION
Very simple, defaults to "Default" (of course), specify the profile folder name in your sublime-settings file.

I use two profiles for my workflow -- one personal, one business -- and this means I will always open a Work profile window when I invoke the inspector within sublime.
