### PR TITLE
Updated Chrome executable path for Windows

### DIFF
--- a/swi.sublime-settings
+++ b/swi.sublime-settings
@@ -2,7 +2,7 @@
 	// Path to google chrome
 	"chrome_path": {
 		"osx": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-		"windows": "C:\\Program Files\\Google\\Chrome\\chrome.exe",
+		"windows": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
 		"linux": "/usr/bin/google-chrome"
 	},
 	// Chrome profile


### PR DESCRIPTION
Changed base directory to Program Files (x86) to match Windows x64 which is much more common. Also chrome.exe lives in the Application subfolder.
