### PR TITLE
Implemented architecture detection for Windows chrome executable, so tha...

### DIFF
--- a/swi.py
+++ b/swi.py
@@ -240,8 +240,8 @@ class SwiDebugStartChromeCommand(sublime_plugin.TextCommand):
         window = sublime.active_window()
         key = sublime.platform()
 
-        if key == "windows":
-            key += "_" + sublime.arch()
+        if key == "windows" and sublime.arch() == "x64":
+            key += "_x64"
 
         window.run_command('exec', {
             "cmd": [os.getenv('GOOGLE_CHROME_PATH', '') + get_setting('chrome_path')[key], '--remote-debugging-port=' + get_setting('chrome_remote_port'), '--profile-directory=' + get_setting('chrome_profile'), '']

--- a/swi.sublime-settings
+++ b/swi.sublime-settings
@@ -2,7 +2,7 @@
 	// Path to google chrome
 	"chrome_path": {
 		"osx": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-		"windows_x32": "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+		"windows": "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
 		"windows_x64": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
 		"linux": "/usr/bin/google-chrome"
 	},


### PR DESCRIPTION
This one is a little better than the last pull request.

Implemented architecture detection for Windows chrome executable, so that 32-bit and 64-bit windows each have their own (hopefully correct) path.

If you have a custom path to Chrome in your user settings and use 64-bit Windows, you must use the key "windows_x64" instead of "windows" for the chrome_path.

Example:

``` json
"chrome_path": {
        "osx": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
        "windows": "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
        "windows_x64": "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
        "linux": "/usr/bin/google-chrome"
    },
```
